### PR TITLE
feat: add two-pass picture text extraction

### DIFF
--- a/adapters/dots_client.py
+++ b/adapters/dots_client.py
@@ -1,0 +1,43 @@
+import json
+import os
+import subprocess
+import tempfile
+from typing import Any, Dict, List, Optional
+
+
+def _run_parser(img_path: str, prompt: str, bbox: Optional[List[float]] = None) -> Dict[str, Any]:
+    """Invoke dots_ocr/parser.py and return parsed JSON output.
+
+    The parser writes its results to a JSONL file inside the provided output
+    directory. This helper runs the parser inside a temporary directory and
+    loads the first JSON object from the resulting file.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cmd = [
+            "python",
+            "dots_ocr/parser.py",
+            img_path,
+            "--prompt",
+            prompt,
+            "--output",
+            tmpdir,
+        ]
+        if bbox is not None:
+            x1, y1, x2, y2 = [str(int(v)) for v in bbox]
+            cmd.extend(["--bbox", x1, y1, x2, y2])
+        subprocess.run(cmd, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        base = os.path.splitext(os.path.basename(img_path))[0]
+        jsonl_path = os.path.join(tmpdir, f"{base}.jsonl")
+        with open(jsonl_path, "r", encoding="utf-8") as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+        return lines[0] if lines else {}
+
+
+def run_layout(img_path: str, prompt: str) -> Dict[str, Any]:
+    """Run dots.ocr once to obtain the full-page layout."""
+    return _run_parser(img_path, prompt)
+
+
+def run_grounding(img_path: str, bbox_xyxy: List[float], prompt: str) -> Dict[str, Any]:
+    """Run dots.ocr within a bounding box to extract picture text."""
+    return _run_parser(img_path, prompt, bbox=bbox_xyxy)

--- a/integrate_children.py
+++ b/integrate_children.py
@@ -1,0 +1,97 @@
+"""Utilities for merging picture-grounding OCR results into layout JSON."""
+from typing import Any, Dict, List, Tuple
+
+
+def _bbox_key(bbox: List[float]) -> Tuple[int, int, int, int]:
+    x1, y1, x2, y2 = bbox
+    return (
+        int(round(x1)),
+        int(round(y1)),
+        int(round(x2)),
+        int(round(y2)),
+    )
+
+
+def _contains(outer: List[float], inner: List[float], tol: float = 0.5) -> bool:
+    """Return True if ``inner`` bbox lies within ``outer`` bbox with tolerance."""
+    ox1, oy1, ox2, oy2 = outer
+    ix1, iy1, ix2, iy2 = inner
+    return (
+        ix1 >= ox1 - tol
+        and iy1 >= oy1 - tol
+        and ix2 <= ox2 + tol
+        and iy2 <= oy2 + tol
+    )
+
+
+def _to_picturetext_block(txt_blk: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert a second-pass Text block into a PictureText block."""
+    out: Dict[str, Any] = {
+        "category": "PictureText",
+        "bbox": [
+            float(txt_blk["bbox"][0]),
+            float(txt_blk["bbox"][1]),
+            float(txt_blk["bbox"][2]),
+            float(txt_blk["bbox"][3]),
+        ],
+        "text": txt_blk.get("text", ""),
+        "source": "picture-ocr",
+    }
+    if "conf" in txt_blk and txt_blk["conf"] is not None:
+        try:
+            out["conf"] = float(txt_blk["conf"])
+        except Exception:
+            pass
+    return out
+
+
+def attach_picture_children(
+    dots_layout: Dict[str, Any],
+    per_picture_grounding: List[Tuple[Dict[str, Any], Dict[str, Any]]],
+    *,
+    dedup_exact: bool = True,
+) -> Dict[str, Any]:
+    """Attach PictureText children to each Picture block in ``dots_layout``.
+
+    ``per_picture_grounding`` is a list of pairs where the first element is the
+    Picture block reference from ``dots_layout['blocks']`` and the second is the
+    grounding OCR JSON result for that picture.
+    """
+    blocks = dots_layout.get("blocks", [])
+    for pic, gjson in per_picture_grounding:
+        if pic.get("category") != "Picture":
+            continue
+        pic.setdefault("children", [])
+
+        seen = set()
+        if dedup_exact:
+            for ch in pic["children"]:
+                if ch.get("category") == "PictureText" and "text" in ch and "bbox" in ch:
+                    seen.add((_bbox_key(ch["bbox"]), ch["text"]))
+
+        pb = pic.get("bbox")
+        if not pb or len(pb) != 4:
+            continue
+
+        for blk in gjson.get("blocks", []):
+            if blk.get("category") != "Text":
+                continue
+            tb = blk.get("bbox")
+            text = blk.get("text", "")
+            if not tb or len(tb) != 4:
+                continue
+            if not _contains(pb, tb):
+                continue
+            if dedup_exact:
+                key = (_bbox_key(tb), text)
+                if key in seen:
+                    continue
+            pic["children"].append(_to_picturetext_block(blk))
+            if dedup_exact:
+                seen.add((_bbox_key(tb), text))
+
+    meta = dots_layout.get("meta", {})
+    meta["merge_version"] = "hier-v1"
+    meta["source"] = "dots+picture2pass"
+    dots_layout["meta"] = meta
+    return dots_layout

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,0 +1,67 @@
+"""Orchestrate two-pass OCR with hierarchical PictureText merging."""
+import argparse
+import json
+import sys
+from typing import Any, Dict, List, Tuple
+
+from adapters.dots_client import run_grounding, run_layout
+from integrate_children import attach_picture_children
+
+
+def collect_pictures(layout_json: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Return all blocks with category == 'Picture'."""
+    return [b for b in layout_json.get("blocks", []) if b.get("category") == "Picture"]
+
+
+def process_page(
+    image_path: str,
+    layout_prompt: str = "prompt_layout_all_en",
+    grounding_prompt: str = "prompt_grounding_ocr",
+    max_pictures_per_page: int = 12,
+) -> Dict[str, Any]:
+    """Run layout OCR and per-picture grounding OCR for an image."""
+    layout = run_layout(image_path, layout_prompt)
+
+    pictures = collect_pictures(layout)
+    if not pictures:
+        meta = layout.get("meta", {})
+        meta.setdefault("source", "dots")
+        layout["meta"] = meta
+        return layout
+
+    per_picture_grounding: List[Tuple[Dict[str, Any], Dict[str, Any]]] = []
+    count = 0
+    for pic in pictures:
+        if count >= max_pictures_per_page:
+            break
+        bbox = pic.get("bbox")
+        if not bbox or len(bbox) != 4:
+            continue
+        gjson = run_grounding(image_path, bbox, grounding_prompt)
+        per_picture_grounding.append((pic, gjson))
+        count += 1
+
+    merged = attach_picture_children(layout, per_picture_grounding)
+    return merged
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--image", required=True, help="Input image or rasterized PDF page")
+    ap.add_argument("--layout-prompt", default="prompt_layout_all_en")
+    ap.add_argument("--grounding-prompt", default="prompt_grounding_ocr")
+    ap.add_argument("--max-pictures-per-page", type=int, default=12)
+    args = ap.parse_args()
+
+    out = process_page(
+        image_path=args.image,
+        layout_prompt=args.layout_prompt,
+        grounding_prompt=args.grounding_prompt,
+        max_pictures_per_page=args.max_pictures_per_page,
+    )
+    json.dump(out, sys.stdout, ensure_ascii=False)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add subprocess wrapper for running dots.ocr and reading JSON results
- merge grounding OCR results into Picture.children as PictureText blocks
- orchestrate first-pass layout and second-pass picture OCR pipeline

## Testing
- `python -m py_compile adapters/dots_client.py integrate_children.py pipeline.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c12cee62c0832eba6e6644fd536c93